### PR TITLE
Threadless io

### DIFF
--- a/src/denon_connection.rs
+++ b/src/denon_connection.rs
@@ -1,10 +1,8 @@
-use crate::logger::Logger;
 use crate::parse::parse;
 use crate::state::{SetState, State, StateValue};
 use crate::stream::{ConnectionStream, ReadStream};
 use std::collections::HashMap;
 use std::io::{self, ErrorKind, Write};
-use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
 
@@ -93,27 +91,19 @@ fn process_receiver_updates(
 }
 
 fn parse_response(response: &[String]) -> Vec<SetState> {
-    return response.iter().filter_map(|x| parse(x.as_str())).collect();
+    response.iter().filter_map(|x| parse(x.as_str())).collect()
 }
 
 pub struct DenonConnection {
     state: HashMap<State, StateValue>,
     to_receiver: Box<dyn ConnectionStream>,
-    logger: Rc<dyn Logger>,
 }
 
 impl DenonConnection {
-    pub fn new(
-        to_receiver: Box<dyn ConnectionStream>,
-        logger: Rc<dyn Logger>,
-    ) -> Result<DenonConnection, io::Error> {
+    pub fn new(to_receiver: Box<dyn ConnectionStream>) -> Result<DenonConnection, io::Error> {
         let state = HashMap::new();
 
-        Ok(DenonConnection {
-            state,
-            to_receiver,
-            logger,
-        })
+        Ok(DenonConnection { state, to_receiver })
     }
 
     pub fn get(&mut self, op: State) -> Result<StateValue, io::Error> {
@@ -149,19 +139,17 @@ pub mod test {
     use crate::denon_connection::{read, write_string};
     use crate::state::{PowerState, SetState, SourceInputState, State, StateValue};
     use crate::stream::{create_tcp_stream, MockReadStream};
-    use crate::StdoutLogger;
     use std::cmp::min;
     use std::collections::HashMap;
     use std::io::{self, Error};
     use std::net::{TcpListener, TcpStream};
-    use std::rc::Rc;
     use std::thread::yield_now;
 
     pub fn create_connected_connection() -> Result<(TcpStream, DenonConnection), io::Error> {
         let listen_socket = TcpListener::bind("localhost:0")?;
         let addr = listen_socket.local_addr()?;
         let s = create_tcp_stream(addr.ip().to_string().as_str(), addr.port())?;
-        let dc = DenonConnection::new(s, Rc::new(StdoutLogger::default()))?;
+        let dc = DenonConnection::new(s)?;
         let (to_denon_client, _) = listen_socket.accept()?;
         Ok((to_denon_client, dc))
     }

--- a/src/denon_connection.rs
+++ b/src/denon_connection.rs
@@ -4,13 +4,9 @@ use crate::state::{SetState, State, StateValue};
 use crate::stream::{ConnectionStream, ReadStream};
 use std::collections::HashMap;
 use std::io::{self, ErrorKind, Write};
-use std::panic;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
-use std::thread::{self, JoinHandle};
+use std::thread;
 use std::time::Duration;
-
-const ESHUTDOWN: i32 = 108;
 
 pub fn write_string(stream: &mut dyn Write, input: &str) -> Result<(), std::io::Error> {
     stream.write_all(input.as_bytes())
@@ -43,12 +39,7 @@ pub fn read(stream: &dyn ReadStream, lines: u8) -> Result<Vec<String>, std::io::
         }
 
         if 0 == read_bytes {
-            // shutdown called
-            if result.is_empty() {
-                return Err(io::Error::from_raw_os_error(ESHUTDOWN));
-            } else {
-                break;
-            }
+            break;
         }
 
         // search for first \r in buffer
@@ -74,28 +65,25 @@ pub fn read(stream: &dyn ReadStream, lines: u8) -> Result<Vec<String>, std::io::
     Ok(result)
 }
 
-fn thread_func_impl(
+fn process_receiver_updates(
     stream: &dyn ReadStream,
-    state: Arc<Mutex<HashMap<State, StateValue>>>,
+    hstate: &mut HashMap<State, StateValue>,
 ) -> Result<(), std::io::Error> {
     loop {
         match read(stream, 1) {
             Ok(status_update) => {
                 let parsed_response = parse_response(&status_update);
-                let mut locked_state = state.lock().unwrap();
                 for sstate in parsed_response {
                     let (state, value) = sstate.convert();
-                    locked_state.insert(state, value);
+                    hstate.insert(state, value);
                 }
             }
-            // check for timeout error -> continue on timeout error, else abort
+            // check for timeout error -> return success on timeout error, else error
             Err(e) => {
                 if ErrorKind::TimedOut != e.kind() && ErrorKind::WouldBlock != e.kind() {
-                    if e.raw_os_error() != Some(ESHUTDOWN) {
-                        return Err(e);
-                    }
-                    return Ok(());
+                    return Err(e);
                 }
+                return Ok(());
             }
         }
     }
@@ -106,9 +94,8 @@ fn parse_response(response: &[String]) -> Vec<SetState> {
 }
 
 pub struct DenonConnection {
-    state: Arc<Mutex<HashMap<State, StateValue>>>,
+    state: HashMap<State, StateValue>,
     to_receiver: Box<dyn ConnectionStream>,
-    thread_handle: Option<JoinHandle<Result<(), io::Error>>>,
     logger: Rc<dyn Logger>,
 }
 
@@ -117,42 +104,33 @@ impl DenonConnection {
         to_receiver: Box<dyn ConnectionStream>,
         logger: Rc<dyn Logger>,
     ) -> Result<DenonConnection, io::Error> {
-        let state = Arc::new(Mutex::new(HashMap::new()));
-        let cloned_state = state.clone();
-        let s2 = to_receiver.get_readstream()?;
-
-        let threadhandle = thread::spawn(move || thread_func_impl(s2.as_ref(), cloned_state));
+        let state = HashMap::new();
 
         Ok(DenonConnection {
             state,
             to_receiver,
-            thread_handle: Some(threadhandle),
             logger,
         })
     }
 
     pub fn get(&mut self, op: State) -> Result<StateValue, io::Error> {
+        process_receiver_updates(self.to_receiver.get_readstream()?.as_ref(), &mut self.state)?;
         // should first check if the requested op is present in state
         // if it is not present it should send the request to the thread and wait until completion
         {
-            let locked_state = self.state.lock().unwrap();
-            if let Some(received_state) = locked_state.get(&op) {
+            if let Some(received_state) = self.state.get(&op) {
                 return Ok(*received_state);
             }
         }
         write_query(&mut self.to_receiver, op)?;
         for _ in 0..50 {
             thread::sleep(Duration::from_millis(10));
-            let locked_state = self.state.lock().unwrap();
-            if let Some(state) = locked_state.get(&op) {
+            process_receiver_updates(self.to_receiver.get_readstream()?.as_ref(), &mut self.state)?;
+            if let Some(state) = self.state.get(&op) {
                 return Ok(*state);
             }
         }
         Ok(StateValue::Unknown)
-    }
-
-    pub fn stop(&mut self) -> Result<(), io::Error> {
-        self.to_receiver.shutdownly()
     }
 
     pub fn set(&mut self, sstate: SetState) -> Result<(), io::Error> {
@@ -160,41 +138,20 @@ impl DenonConnection {
     }
 }
 
-impl Drop for DenonConnection {
-    fn drop(&mut self) {
-        let _ = self.stop();
-        let thread_result = self
-            .thread_handle
-            .take()
-            .expect("Non running thread is a bug")
-            .join();
-        match thread_result {
-            Ok(result) => {
-                if let Err(e) = result {
-                    self.logger.log(&format!("got error: {}", e));
-                }
-            }
-            Err(e) => panic::resume_unwind(e),
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod test {
     use mockall::Sequence;
-    use predicates::ord::eq;
 
-    use super::{thread_func_impl, DenonConnection};
+    use super::{process_receiver_updates, DenonConnection};
     use crate::denon_connection::{read, write_string};
-    use crate::logger::{nothing, MockLogger};
     use crate::state::{PowerState, SetState, SourceInputState, State, StateValue};
-    use crate::stream::{create_tcp_stream, MockReadStream, MockShutdownStream};
+    use crate::stream::{create_tcp_stream, MockReadStream};
     use crate::StdoutLogger;
     use std::cmp::min;
+    use std::collections::HashMap;
     use std::io::{self, Error};
     use std::net::{TcpListener, TcpStream};
     use std::rc::Rc;
-    use std::sync::Arc;
     use std::thread::yield_now;
 
     pub fn create_connected_connection() -> Result<(TcpStream, DenonConnection), io::Error> {
@@ -363,8 +320,8 @@ pub mod test {
         mstream
             .expect_peekly()
             .returning(|_| Err(Error::from(io::ErrorKind::ConnectionAborted)));
-        let state = Arc::default();
-        let thread_err = thread_func_impl(&mstream, state);
+        let mut state = HashMap::default();
+        let thread_err = process_receiver_updates(&mstream, &mut state);
         assert!(thread_err.is_err());
         assert_eq!(
             io::ErrorKind::ConnectionAborted,
@@ -373,7 +330,7 @@ pub mod test {
     }
 
     #[test]
-    fn thread_func_impl_gets_timeout_then_error_and_returns() {
+    fn thread_func_impl_gets_timeout_and_returns() {
         let mut sequence = Sequence::new();
         let mut mstream = MockReadStream::new();
         mstream
@@ -381,46 +338,8 @@ pub mod test {
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| Err(Error::from(io::ErrorKind::TimedOut)));
-        mstream
-            .expect_peekly()
-            .once()
-            .in_sequence(&mut sequence)
-            .returning(|_| Err(Error::from(io::ErrorKind::ConnectionAborted)));
-        let state = Arc::default();
-        let thread_err = thread_func_impl(&mstream, state);
-        assert!(thread_err.is_err());
-        assert_eq!(
-            io::ErrorKind::ConnectionAborted,
-            thread_err.unwrap_err().kind()
-        );
-    }
-
-    #[test]
-    fn drop_gets_error() {
-        static ERROR_MESSAGE: &str = "blub";
-        let mut msdstream = MockShutdownStream::new();
-
-        msdstream.expect_get_readstream().once().returning(|| {
-            let mut blub = MockReadStream::new();
-            blub.expect_peekly().once().returning(|_| {
-                Err(io::Error::new(
-                    io::ErrorKind::ConnectionAborted,
-                    ERROR_MESSAGE,
-                ))
-            });
-            Ok(Box::new(blub))
-        });
-
-        msdstream.expect_shutdownly().once().returning(|| Ok(()));
-
-        let mut logger = MockLogger::new();
-        logger
-            .expect_log()
-            .once()
-            .with(eq(format!("got error: {}", ERROR_MESSAGE)))
-            .returning(nothing);
-
-        let dc = DenonConnection::new(Box::new(msdstream), Rc::new(logger));
-        assert!(dc.is_ok());
+        let mut state = HashMap::default();
+        let thread_err = process_receiver_updates(&mstream, &mut state);
+        assert!(thread_err.is_ok());
     }
 }

--- a/src/denon_connection.rs
+++ b/src/denon_connection.rs
@@ -73,6 +73,9 @@ fn process_receiver_updates(
         match read(stream, 1) {
             Ok(status_update) => {
                 let parsed_response = parse_response(&status_update);
+                if status_update.is_empty() {
+                    return Ok(());
+                }
                 for sstate in parsed_response {
                     let (state, value) = sstate.convert();
                     hstate.insert(state, value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ mod test {
     use crate::error::Error;
     use crate::logger::{nothing, MockLogger};
     use crate::state::{PowerState, SetState, SourceInputState, State};
-    use crate::stream::{create_tcp_stream, MockReadStream, MockShutdownStream};
+    use crate::stream::{create_tcp_stream, MockShutdownStream};
     use crate::{avahi, avahi3, avahi_error, GetReceiverFn};
     use crate::{get_avahi_impl, get_receiver_and_port, main2, parse_args, print_status};
     use predicates::ord::eq;
@@ -377,27 +377,11 @@ mod test {
 
     #[test]
     fn main2_less_args_test() -> Result<(), io::Error> {
-        let mut mlogger = Box::new(MockLogger::new());
+        let mlogger = Box::new(MockLogger::new());
         let string_args = vec!["blub", "-a", "localhost"];
         let args = parse_args(to_string_vec(string_args), &*mlogger);
 
-        let mut msdstream = Box::new(MockShutdownStream::new());
-
-        msdstream.expect_get_readstream().once().returning(|| {
-            let mut blub = MockReadStream::new();
-            blub.expect_peekly()
-                .once()
-                .returning(|_| Err(io::Error::new(io::ErrorKind::ConnectionAborted, "ha")));
-            Ok(Box::new(blub))
-        });
-
-        msdstream.expect_shutdownly().once().returning(|| Ok(()));
-
-        mlogger
-            .expect_log()
-            .once()
-            .with(eq("got error: ha"))
-            .returning(nothing);
+        let msdstream = Box::new(MockShutdownStream::new());
 
         main2(args, msdstream, mlogger).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ use getopts::Options;
 use logger::Logger;
 pub use logger::StdoutLogger;
 use state::{get_state, PowerState, SetState, SourceInputState, State};
-use std::rc::Rc;
 pub use stream::create_tcp_stream;
 use stream::ConnectionStream;
 
@@ -110,11 +109,10 @@ pub fn main2(
     stream: Box<dyn ConnectionStream>,
     logger: Box<dyn Logger>,
 ) -> Result<(), Error> {
-    let rclogger: Rc<dyn Logger> = logger.into();
-    let mut dc = DenonConnection::new(stream, rclogger.clone())?;
+    let mut dc = DenonConnection::new(stream)?;
 
     if args.opt_present("s") {
-        rclogger.log(&print_status(&mut dc)?);
+        logger.log(&print_status(&mut dc)?);
     }
     if let Some(p) = args.opt_str("p") {
         let state = get_state(PowerState::states(), p.as_str())?;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,15 +23,10 @@ impl ReadStream for TcpStream {
 }
 
 pub trait ConnectionStream: Write {
-    fn shutdownly(&self) -> io::Result<()>;
     fn get_readstream(&self) -> io::Result<Box<dyn ReadStream>>;
 }
 
 impl ConnectionStream for TcpStream {
-    fn shutdownly(&self) -> io::Result<()> {
-        self.shutdown(std::net::Shutdown::Both)
-    }
-
     fn get_readstream(&self) -> io::Result<Box<dyn ReadStream>> {
         Ok(Box::new(self.try_clone()?))
     }
@@ -45,7 +40,6 @@ mock! {
         fn flush(&mut self) -> io::Result<()>;
     }
     impl ConnectionStream for ShutdownStream {
-        fn shutdownly(&self) -> io::Result<()>;
         fn get_readstream(&self) -> io::Result<Box<dyn ReadStream>>;
     }
 }
@@ -55,8 +49,7 @@ pub fn create_tcp_stream(
     denon_port: u16,
 ) -> Result<Box<dyn ConnectionStream>, io::Error> {
     let s = TcpStream::connect((denon_name, denon_port))?;
-    s.set_read_timeout(None)?;
-    s.set_nonblocking(false)?;
+    s.set_nonblocking(true)?;
     Ok(Box::new(s))
 }
 

--- a/tests/denon-control.rs
+++ b/tests/denon-control.rs
@@ -227,7 +227,7 @@ fn setting_invalid_power_prints_error(power: &str) -> Result<(), Box<dyn std::er
         .stderr(contains(format!("given value {} does not match", power)));
 
     let mut to_receiver = acceptor.join().unwrap()?;
-    assert!(read(&mut to_receiver, 10).unwrap().is_empty());
+    assert!(read(&mut to_receiver, 10)?.is_empty());
 
     Ok(())
 }
@@ -265,7 +265,7 @@ fn input_prints_error(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         .stderr(contains(format!("given value {} does not match", input)));
 
     let mut to_receiver = acceptor.join().unwrap()?;
-    assert!(read(&mut to_receiver, 10).unwrap().is_empty());
+    assert!(read(&mut to_receiver, 10)?.is_empty());
 
     Ok(())
 }
@@ -303,7 +303,7 @@ fn setting_invalid_volume_prints_error(volume: &str) -> Result<(), Box<dyn std::
         .stderr(contains(String::from("ParseInt")));
 
     let mut to_receiver = acceptor.join().unwrap()?;
-    assert!(read(&mut to_receiver, 10).unwrap().is_empty());
+    assert!(read(&mut to_receiver, 10)?.is_empty());
 
     Ok(())
 }

--- a/tests/denon-control.rs
+++ b/tests/denon-control.rs
@@ -227,7 +227,7 @@ fn setting_invalid_power_prints_error(power: &str) -> Result<(), Box<dyn std::er
         .stderr(contains(format!("given value {} does not match", power)));
 
     let mut to_receiver = acceptor.join().unwrap()?;
-    assert!(read(&mut to_receiver, 10).is_err());
+    assert!(read(&mut to_receiver, 10).unwrap().is_empty());
 
     Ok(())
 }
@@ -265,7 +265,7 @@ fn input_prints_error(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         .stderr(contains(format!("given value {} does not match", input)));
 
     let mut to_receiver = acceptor.join().unwrap()?;
-    assert!(read(&mut to_receiver, 10).is_err());
+    assert!(read(&mut to_receiver, 10).unwrap().is_empty());
 
     Ok(())
 }
@@ -303,7 +303,7 @@ fn setting_invalid_volume_prints_error(volume: &str) -> Result<(), Box<dyn std::
         .stderr(contains(String::from("ParseInt")));
 
     let mut to_receiver = acceptor.join().unwrap()?;
-    assert!(read(&mut to_receiver, 10).is_err());
+    assert!(read(&mut to_receiver, 10).unwrap().is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
It was never needed to process incoming data with a thread, because `get()`blocks until the data arrives anyway.