### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,8 @@ jobs:
         lcov-file: lcov.info
 
   check-formatting:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -39,6 +41,8 @@ jobs:
       run: cargo fmt --check
 
   check-static-code-analysis:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/lurtz/denon-control/security/code-scanning/1](https://github.com/lurtz/denon-control/security/code-scanning/1)

To fix the issue, we need to add explicit `permissions` blocks to the `check-formatting` and `check-static-code-analysis` jobs. These blocks should specify the least privileges required for the jobs to function correctly. Since these jobs only perform read operations (e.g., checking formatting and running static code analysis), the `contents: read` permission is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
