### PR TITLE
Fix clippy findings to unblock dependabot

### DIFF
--- a/src/avahi3.rs
+++ b/src/avahi3.rs
@@ -47,14 +47,12 @@ fn on_service_discovered(
     result: zeroconf::Result<ServiceDiscovery>,
     context: Option<Arc<dyn Any>>,
 ) {
-    if let Ok(sd) = result {
-        if let Some(ctx) = context {
-            if let Some(m) = ctx.downcast_ref::<Arc<Mutex<Context>>>() {
-                if let Ok(mut ctx) = m.lock() {
-                    ctx.service_discovery = Some(sd);
-                }
-            }
-        }
+    if let Ok(sd) = result
+        && let Some(ctx) = context
+        && let Some(m) = ctx.downcast_ref::<Arc<Mutex<Context>>>()
+        && let Ok(mut ctx) = m.lock()
+    {
+        ctx.service_discovery = Some(sd);
     }
 }
 


### PR DESCRIPTION
Dependabot is blocked because not a fixed version of Rust is used. A version upgrade got better syntax and a clippy fix.